### PR TITLE
load be url from runtime using config.js

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Replace placeholder with actual environment variable
+if [ ! -z "$NEXT_PUBLIC_GRAPHQL_URI" ]; then
+  echo "Setting NEXT_PUBLIC_GRAPHQL_URI to: $NEXT_PUBLIC_GRAPHQL_URI"
+  sed -i "s|__NEXT_PUBLIC_GRAPHQL_URI__|$NEXT_PUBLIC_GRAPHQL_URI|g" /app/public/config.js
+else
+  echo "Warning: NEXT_PUBLIC_GRAPHQL_URI is not set"
+fi
+
+# Execute the original command
+exec "$@" 

--- a/dockerfile
+++ b/dockerfile
@@ -13,6 +13,10 @@ RUN bun install
 # Copy all source files
 COPY . .
 
+# Build argument for the GraphQL URI
+ARG NEXT_PUBLIC_GRAPHQL_URI
+ENV NEXT_PUBLIC_GRAPHQL_URI=$NEXT_PUBLIC_GRAPHQL_URI
+
 # Build the Next.js application
 # NEXT_PUBLIC_ variables available at build time would be embedded here.
 # Since we want runtime, this build will not embed NEXT_PUBLIC_BACKEND_URL
@@ -40,8 +44,15 @@ RUN bun install
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 
+# Copy the entrypoint script
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # Expose the default Next.js port
 EXPOSE 3000
+
+# Use the entrypoint script
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 # Command to run the application
 # 'bun start' (which typically runs 'next start') will pick up runtime environment variables.

--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,5 @@
+// Runtime configuration
+// This file is served as a static asset and can be modified at runtime
+window.__RUNTIME_CONFIG__ = {
+  NEXT_PUBLIC_GRAPHQL_URI: '__NEXT_PUBLIC_GRAPHQL_URI__'
+}; 

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -41,6 +41,9 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap"
             rel="stylesheet"
           />
+          
+          {/* Runtime configuration script */}
+          <script src="/config.js" />
         </Head>
 
         <body>


### PR DESCRIPTION
## What I've done:
- Created a runtime configuration solution:
- Added``` public/config.js``` with a placeholder for the GraphQL URI
- Created ```docker-entrypoint.sh``` script that replaces the placeholder at container startup
- Updated apollo-client.js to read from ```window.__RUNTIME_CONFIG__``` first
- Modified``` _document.js``` to include the config.js script
- Updated the Dockerfile to use the entrypoint script

## How it works:
- When the container starts, the entrypoint script replaces``` __NEXT_PUBLIC_GRAPHQL_URI__``` in config.js with the actual value from the environment variable
- The browser loads ```config.js``` which sets ```window.__RUNTIME_CONFIG__```
Apollo Client reads the URI from this runtime configuration